### PR TITLE
rlp: Fix bug in decodeLength code

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -88,7 +88,7 @@ func encodeLength(t byte, l int) []byte {
 	)
 }
 
-// Returns  two values representing the length of the
+// Returns two values representing the length of the
 // header and payload respectively.
 func decodeLength(t byte, input []byte) (int, int) {
 	n := input[0] - t

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -92,7 +92,11 @@ func encodeLength(t byte, l int) []byte {
 // header and payload respectively.
 func decodeLength(t byte, input []byte) (int, int) {
 	n := input[0] - t
-	length, _ := binary.Uvarint(input[1 : n+1])
+	paddedBytes := make([]byte, 8)
+	// binary.BigEndian.Uint64 expects an 8 byte array so we have to left pad
+	// it in case the length is less. Big-endian format is used.
+	copy(paddedBytes[8-n:], input[1 : n+1])
+	length := binary.BigEndian.Uint64(paddedBytes)
 	return int(n + 1), int(length)
 }
 

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -105,6 +105,55 @@ func TestDecode_Errors(t *testing.T) {
 	}
 }
 
+func TestDecodeLength(t *testing.T) { 
+	cases := []struct {
+		t byte
+		header []byte
+		expectedLength int
+	}{
+		// list more than 55 bytes, full 8 bytes needed for length
+		{
+			t: list55H,
+			header: []byte{0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedLength: 1 << 56,
+		},
+		// list more than 55 bytes, but binary encoding of length only fits into one byte
+		{
+			t: list55H,
+			header: []byte{list55H + 1, 0xe2},
+			expectedLength: 226, // e2 is 226 in decimal
+		},
+		// list more than 55 bytes, but binary encoding of length  fits into two bytes
+		{
+			t: list55H,
+			header: []byte{list55H + 2, 0x12, 0xab},
+			expectedLength: 4779, // 12ab is 4779 in decimal
+		},
+		// string more than 55 bytes, but binary encoding of length fits into two bytes
+		{
+			t: str55H,
+			header: []byte{str55H + 2, 0x12, 0xab},
+			expectedLength: 4779, // 12ab is 4779 in decimal
+		},
+		// string more than 55 bytes, but binary encoding of length fits into two bytes
+		{
+			t: str55H,
+			header: []byte{str55H + 2, 0x12, 0xab},
+			expectedLength: 4779, // 12ab is 4779 in decimal
+		},
+	}
+
+	for _, c := range cases {
+		gotHeaderLength, gotLength := decodeLength(c.t, c.header)
+		if gotHeaderLength != len(c.header) {
+			t.Errorf("expected header length %d, got %d", gotHeaderLength, len(c.header))
+		}
+		if gotLength != c.expectedLength {
+			t.Errorf("expected length %d, got %d", gotLength, c.expectedLength)
+		}
+	}
+}
+
 func TestDecode(t *testing.T) {
 	cases := []struct {
 		desc string


### PR DESCRIPTION
There is a bug in the `decodeLength` method where `binary.Uvarint(input[1 : n+1])` fails to return the length of the list *if input[1:n+1] is not an 8 byte array*. This is because `binary.Uvarint` always expects an 8 byte array as an input so it can return a `uint64`. To solve this issue, we must left pad it to 8 bytes (since it uses big-Endian).